### PR TITLE
Bump to Fluxor 4.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/FluxorOrg/Fluxor",
         "state": {
           "branch": null,
-          "revision": "35b2a6aba3f768deb75f1dd1ab468438e4dd5c90",
-          "version": "3.0.0"
+          "revision": "f15306d661b26a568651a179e583c0e8f6033add",
+          "version": "4.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/FluxorOrg/Fluxor",
-            from: "3.0.0"),
+            from: "4.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
I would like to use [FluxorExplorerInterceptor](https://github.com/FluxorOrg/FluxorExplorerInterceptor) with `Fluxor` 4.0.0, but dependency could not be resolved.

I will also submit a PR to bump on `FluxorExplorerInterceptor` after this PR is merged.